### PR TITLE
use cmake add_definitions instead of Config.hpp

### DIFF
--- a/BCCoreSiconos.h
+++ b/BCCoreSiconos.h
@@ -32,8 +32,6 @@
 #ifndef CNOID_BCPLUGIN_CORE_H
 #define CNOID_BCPLUGIN_CORE_H
 
-#include "Config.hpp"
-
 #ifdef BUILD_BCPLUGIN_WITH_SICONOS
 #include "SiconosNumerics.h"
 #include "FrictionContactProblem.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,7 @@ endif()
 
 include(cmake/Findsiconos.cmake)
 
-configure_file (${CMAKE_CURRENT_SOURCE_DIR}/Config.hpp.in
-                ${CMAKE_CURRENT_BINARY_DIR}/Config.hpp)
-
-message (STATUS "Generating Config.hpp ...")
 message (STATUS "USE_SICONOS=${BUILD_BCPLUGIN_WITH_SICONOS}")
-
-
 
 set(target CnoidBCPlugin)
 
@@ -37,6 +31,7 @@ if(BUILD_BCPLUGIN_WITH_SICONOS)
   include_directories(
     ${SICONOS_INCLUDE_DIR}
   )
+  add_definitions( -DBUILD_BCPLUGIN_WITH_SICONOS )
 endif()
 
 make_gettext_mofiles(${target} mofiles)

--- a/Config.hpp.in
+++ b/Config.hpp.in
@@ -1,1 +1,0 @@
-#cmakedefine BUILD_BCPLUGIN_WITH_SICONOS


### PR DESCRIPTION
Config.hppが環境によってうまく生成できない現象があったので、add_definitionsを使う方法に切り替えました。
